### PR TITLE
✈ [FEAT] 검색결과 없을시 분기처리, UI와 정렬 연결

### DIFF
--- a/src/app/impl/search/SearchServiceImpl.java
+++ b/src/app/impl/search/SearchServiceImpl.java
@@ -83,11 +83,11 @@ public class SearchServiceImpl implements ServiceFrame<String, Product> {
 	        case "sales":
 	            searchedList.sort(Comparator.comparing(SearchProductMapper::getSalesCount).reversed());
 	            break;
-	        case "high to low":
-	            searchedList.sort(Comparator.comparing(SearchProductMapper::getPrice).reversed());
+	        case "high_to_low":
+	            searchedList.sort(Comparator.comparing(SearchProductMapper::getDiscountedPrice).reversed());
 	            break;
-	        case "low to high":
-	            searchedList.sort(Comparator.comparing(SearchProductMapper::getPrice));
+	        case "low_to_high":
+	            searchedList.sort(Comparator.comparing(SearchProductMapper::getDiscountedPrice));
 	            break;
 	        case "popular": // 기본이 popular. popular 점수에 리뷰점수가 없는(쿼리에서 null 대용으로 0 넣었음.) 경우 3점으로 세팅
 	        default:

--- a/src/web/controller/ProductDetailServlet.java
+++ b/src/web/controller/ProductDetailServlet.java
@@ -19,7 +19,7 @@ import app.impl.product.ProductServiceImpl;
 public class ProductDetailServlet implements ControllerFrame {
 	private static final long serialVersionUID = 1L;
 	private ProductServiceImpl productServiceImpl;
-	private Logger product_detail_log = Logger.getLogger("productDetailController");
+	private Logger product_detail_log = Logger.getLogger("product-detail");
 
 	public ProductDetailServlet() {
 		super();

--- a/src/web/controller/SearchServlet.java
+++ b/src/web/controller/SearchServlet.java
@@ -1,17 +1,12 @@
 package web.controller;
 
-import java.io.IOException;
-
 import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
 
-import app.dto.response.ProductDetailWithReviews;
 import app.dto.response.SearchResult;
 import app.frame.ControllerFrame;
 import app.impl.search.SearchServiceImpl;
@@ -20,7 +15,7 @@ import app.impl.search.SearchServiceImpl;
 public class SearchServlet implements ControllerFrame {
 	private static final long serialVersionUID = 1L;
 	private SearchServiceImpl searchServiceImpl; //
-	private Logger search_log = Logger.getLogger("SearchController"); //
+	private Logger search_log = Logger.getLogger("search"); //
 
 	public SearchServlet() {
 		super();
@@ -84,6 +79,7 @@ public class SearchServlet implements ControllerFrame {
 		String view = request.getParameter("view");
 		// System.out.println(view);
 		search_log.debug("상품 디테일 컨트롤러로 들어옴");
+		search_log.warn("warn도 됩니까?");
 		if (view != null) {
 			build(request, view);
 		}

--- a/webapp/WEB-INF/log4j.properties
+++ b/webapp/WEB-INF/log4j.properties
@@ -7,6 +7,8 @@
 log4j.logger.user = DEBUG, console, user
 log4j.logger.work = DEBUG, console, work
 log4j.logger.data = DEBUG, console, data
+log4j.logger.search = DEBUG, console, search
+log4j.logger.product-detail = DEBUG, console, product-detail
 
 # Console output... 
 log4j.appender.console= org.apache.log4j.ConsoleAppender 
@@ -37,3 +39,20 @@ log4j.appender.data.layout = org.apache.log4j.PatternLayout
 log4j.appender.data.layout.ConversionPattern = %5p  [%d{MMdd HHmmss}] %F:%L:%M - %m%n
 log4j.appender.data.File = c:/logs/data.log 
 
+
+# search
+log4j.appender.search.Threadhold=DEBUG
+log4j.appender.search = org.apache.log4j.DailyRollingFileAppender 
+log4j.appender.search.DatePattern = '.'yyyy-MM-dd
+log4j.appender.search.layout = org.apache.log4j.PatternLayout 
+log4j.appender.search.layout.ConversionPattern = %5p  [%d{MMdd HHmmss}] %F:%L:%M - %m%n
+log4j.appender.search.File = c:/logs/search.log  
+
+
+# product-detail
+log4j.appender.product-detail.Threadhold=DEBUG
+log4j.appender.product-detail = org.apache.log4j.DailyRollingFileAppender 
+log4j.appender.product-detail.DatePattern = '.'yyyy-MM-dd
+log4j.appender.product-detail.layout = org.apache.log4j.PatternLayout 
+log4j.appender.product-detail.layout.ConversionPattern = %5p  [%d{MMdd HHmmss}] %F:%L:%M - %m%n
+log4j.appender.product-detail.File = c:/logs/product-detail.log  

--- a/webapp/index.jsp
+++ b/webapp/index.jsp
@@ -87,6 +87,36 @@
     <script src="js/mixitup.min.js"></script>
     <script src="js/owl.carousel.min.js"></script>
     <script src="js/main.js"></script>
+    <script>	
+        function search(keyword) {
+             // 키워드가 비어있는지 확인
+            if (!keyword) {
+                alert("검색어를 입력해주세요.");
+                return;
+            }
+    
+            // 키워드의 길이가 너무 짧은지 확인 (예: 2글자 이상)
+            if (keyword.length < 2) {
+                alert("검색어는 최소 2글자 이상 입력해주세요.");
+                return;
+            }
+    
+            //특수문자나 공백이 있는지 확인
+            let special_pattern = /[`~!@#$%^&*|\\\'\";:\/?]/gi;
+            if(special_pattern.test(keyword)) {
+                alert("특수문자는 검색어로 사용하실 수 없습니다.");
+                return;
+            }
+    
+            if(!keyword.trim()) { 
+                alert("공백만으로 구성된 검색어는 사용하실 수 없습니다.");
+                return;
+            }
+            
+            window.location.href = 'search.bit?view=search&keyword=' + keyword + '&orderby=popular'
+        }
+    </script>
+    
 </body>
 
 </html>

--- a/webapp/main.jsp
+++ b/webapp/main.jsp
@@ -1,309 +1,335 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%
-   String[] BestSeller = request.getParameterValues("BestSeller");
-   String[] Latest = request.getParameterValues("Latest");
-   String[] BigPoint = request.getParameterValues("BigPoint");
-   String[] BigDiscount = request.getParameterValues("BigDiscount");
+String[] BestSeller = request.getParameterValues("BestSeller");
+String[] Latest = request.getParameterValues("Latest");
+String[] BigPoint = request.getParameterValues("BigPoint");
+String[] BigDiscount = request.getParameterValues("BigDiscount");
 %>
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
+<link rel="stylesheet"
+	href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+<script
+	src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 
 
 <!-- Header Section Begin -->
 <header class="header">
-   <div class="header__top">
-      <div class="container">
-         <nav class="header__menu header__top__right mobile-menu" 
-            style="padding: 5px 0">
-            <ul>
-               <c:choose>
-                  <c:when test="${logincust != null }">
-                     <li class="active"><a href="main.bit?view=mypage&memberSeq=${logincust.sequence }"><i
-                           class="fa fa-user"></i> 마이페이지</a></li>
-                     <li class=""><a href="member.bit?view=logout"><i
-                           class="fa fa-user"></i> 로그아웃</a></li>
-                  </c:when>
-                  <c:otherwise>
-                     <li class="active"><a href="main.bit?view=signin"><i
-                           class="fa fa-user"></i> 로그인</a></li>
-                     <li class=""><a href="main.bit?view=signup"><i
-                           class="fa fa-user"></i> 회원가입</a></li>
-                  </c:otherwise>
-               </c:choose>
+	<div class="header__top">
+		<div class="container">
+			<nav class="header__menu header__top__right mobile-menu"
+				style="padding: 5px 0">
+				<ul>
+					<c:choose>
+						<c:when test="${logincust != null }">
+							<li class="active"><a
+								href="main.bit?view=mypage&memberSeq=${logincust.sequence }"><i
+									class="fa fa-user"></i> 마이페이지</a></li>
+							<li class=""><a href="member.bit?view=logout"><i
+									class="fa fa-user"></i> 로그아웃</a></li>
+						</c:when>
+						<c:otherwise>
+							<li class="active"><a href="main.bit?view=signin"><i
+									class="fa fa-user"></i> 로그인</a></li>
+							<li class=""><a href="main.bit?view=signup"><i
+									class="fa fa-user"></i> 회원가입</a></li>
+						</c:otherwise>
+					</c:choose>
 
-            </ul>
-         </nav>
-      </div>
-   </div>
-   <div class="container">
-      <div class="row">
-         <div class="col-lg-3">
-            <div class="header__logo">
-               <a href="./index.jsp"><img src="img/logo.png" alt=""></a>
-            </div>
-         </div>
-         <div class="col-lg-6">
-            <nav class="header__menu">
-               <ul id="header__menus">
-                  <li class="active"><a href="./index.jsp">Home</a></li>
-                  <li><a href="main.bit?view=shop-grid">Shop</a></li>
-                  <li><a href="#">Pages</a>
-                     <ul class="header__menu__dropdown">
-                        <li><a href="main.bit?view=shop-details">Shop Details</a></li>
-                        <li><a href="main.bit?view=shoping-cart">Shopping Cart</a></li>
-                        <li><a href="main.bit?view=checkout">Check Out</a></li>
+				</ul>
+			</nav>
+		</div>
+	</div>
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-3">
+				<div class="header__logo">
+					<a href="./index.jsp"><img src="img/logo.png" alt=""></a>
+				</div>
+			</div>
+			<div class="col-lg-6">
+				<nav class="header__menu">
+					<ul id="header__menus">
+						<li class="active"><a href="./index.jsp">Home</a></li>
+						<li><a href="main.bit?view=shop-grid">Shop</a></li>
+						<li><a href="#">Pages</a>
+							<ul class="header__menu__dropdown">
+								<li><a href="main.bit?view=shop-details">Shop Details</a></li>
+								<li><a href="main.bit?view=shoping-cart">Shopping Cart</a></li>
+								<li><a href="main.bit?view=checkout">Check Out</a></li>
 
-                     </ul></li>
-                  <li><a href="main.bit?view=contact" onclick=li_click(3)>Contact</a></li>
-               </ul>
-            </nav>
-         </div>
-         <c:choose>
-            <c:when test="${logincust != null }">
-               <div class="col-lg-3">
-                  <div class="header__cart">
-                     <ul>
-                        <li><a href="main.bit?view=shopping-cart&memberSeq=${logincust.sequence }"><i class="fa fa-shopping-bag"></i> <span>${cartCount }</span></a></li>
-                     </ul>
-                  </div>
-               </div>
-            </c:when>
-            <c:otherwise>
-            </c:otherwise>
-         </c:choose>
-      </div>
-      <div class="humberger__open">
-         <i class="fa fa-bars"></i>
-      </div>
-   </div>
+							</ul></li>
+						<li><a href="main.bit?view=contact" onclick=li_click(3)>Contact</a></li>
+					</ul>
+				</nav>
+			</div>
+			<c:choose>
+				<c:when test="${logincust != null }">
+					<div class="col-lg-3">
+						<div class="header__cart">
+							<ul>
+								<li><a
+									href="main.bit?view=shopping-cart&memberSeq=${logincust.sequence }"><i
+										class="fa fa-shopping-bag"></i> <span>${cartCount }</span></a></li>
+							</ul>
+						</div>
+					</div>
+				</c:when>
+				<c:otherwise>
+				</c:otherwise>
+			</c:choose>
+		</div>
+		<div class="humberger__open">
+			<i class="fa fa-bars"></i>
+		</div>
+	</div>
 </header>
 <!-- Header Section End -->
 <!-- Hero Section Begin -->
 <section class="hero">
-   <div class="container">
-      <div class="row">
-         <div class="col-lg-3">
-            <div class="hero__categories">
-               <div class="hero__categories__all">
-                  <i class="fa fa-bars"></i> <span>카테고리</span>
-               </div>
-               <ul>
-                  <li value="1"><a href="#" class="font-weight-bold">컴퓨터 /
-                        IT</a>
-                  <li value="2"><a href="#" style="text-indent: 20px">컴퓨터
-                        공학</a>
-                  <li value="3"><a href="#" style="text-indent: 20px">데이터베이스</a>
-                  <li value="4"><a href="#" style="text-indent: 20px">네트워크</a>
-                  <li value="5"><a href="#" style="text-indent: 20px">프로그래밍</a>
-                  <li value="6"><a href="#" class="font-weight-bold">소설</a></li>
-                  <li value="7"><a href="#" style="text-indent: 20px">한국소설</a>
-                  <li value="8"><a href="#" style="text-indent: 20px">영미소설</a>
-                  <li value="9"><a href="#" style="text-indent: 20px">일본소설</a>
-                  <li value="10"><a href="#" class="font-weight-bold">경제 /
-                        경영</a></li>
-                  <li value="11"><a href="#" style="text-indent: 20px">경영일반</a>
-                  <li value="12"><a href="#" style="text-indent: 20px">재테크/금융</a>
-                  <li value="13"><a href="#" style="text-indent: 20px">유통/창업</a>
-                  <li value="14"><a href="#" style="text-indent: 20px">세무/회계</a>
-               </ul>
-            </div>
-         </div>
-         <div class="col-lg-9">
-            <div class="hero__search">
-               <div class="hero__search__form">
-                  <form action="#">
-                     <div class="hero__search__categories">통합 검색</div>
-                     <input type="text" placeholder="검색어를 입력해주세요">
-                     <button type="submit" class="site-btn">검색</button>
-                  </form>
-               </div>
-            </div>
-            <div>
-               <img class="hero__item" src="img/banner.png">
-            </div>
-         </div>
-      </div>
-   </div>
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-3">
+				<div class="hero__categories">
+					<div class="hero__categories__all">
+						<i class="fa fa-bars"></i> <span>카테고리</span>
+					</div>
+					<ul>
+						<li value="1"><a href="#" class="font-weight-bold">컴퓨터 /
+								IT</a>
+						<li value="2"><a href="#" style="text-indent: 20px">컴퓨터
+								공학</a>
+						<li value="3"><a href="#" style="text-indent: 20px">데이터베이스</a>
+						<li value="4"><a href="#" style="text-indent: 20px">네트워크</a>
+						<li value="5"><a href="#" style="text-indent: 20px">프로그래밍</a>
+						<li value="6"><a href="#" class="font-weight-bold">소설</a></li>
+						<li value="7"><a href="#" style="text-indent: 20px">한국소설</a>
+						<li value="8"><a href="#" style="text-indent: 20px">영미소설</a>
+						<li value="9"><a href="#" style="text-indent: 20px">일본소설</a>
+						<li value="10"><a href="#" class="font-weight-bold">경제 /
+								경영</a></li>
+						<li value="11"><a href="#" style="text-indent: 20px">경영일반</a>
+						<li value="12"><a href="#" style="text-indent: 20px">재테크/금융</a>
+						<li value="13"><a href="#" style="text-indent: 20px">유통/창업</a>
+						<li value="14"><a href="#" style="text-indent: 20px">세무/회계</a>
+					</ul>
+				</div>
+			</div>
+			<div class="col-lg-9">
+				<div class="hero__search">
+					<div class="hero__search__form">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
+							<div class="hero__search__categories">통합 검색</div>
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
+							<button type="submit" class="site-btn">검색</button>
+						</form>
+					</div>
+				</div>
+				<div>
+					<img class="hero__item" src="img/banner.png">
+				</div>
+			</div>
+
+		</div>
+	</div>
 </section>
 <!-- Hero Section End -->
 
 <!-- Featured Section Begin -->
 <section class="featured spad">
-   <div class="container">
-      <div class="row">
-         <div class="col-lg-12">
-            <div class="section-title">
-               <h2>🥰꾸준히 사랑받는 작품🥰</h2>
-            </div>
-            <div class="featured__controls">
-               <ul>
-                  <li data-filter="*">전체</li>
-               </ul>
-            </div>
-         </div>
-      </div>
-      <!-- Categories Section Begin -->
-      <section class="categories">
-         <div class="container">
-            <div class="row">
-               <div class="categories__slider owl-carousel">
-                  <c:forEach items="${BestSeller }" var="product">
-                     <div class="col-lg-3">
-                     	<a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}">
-	                        <div class="categories__item set-bg"
-	                           data-setbg="${product.productImgurl }" style="width: 200px;">
-	                        </div>
-	                    </a>
-                     </div>
-                  </c:forEach>
-               </div>
-            </div>
-         </div>
-      </section>
-      <!-- Categories Section End -->
-   </div>
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-12">
+				<div class="section-title">
+					<h2>🥰꾸준히 사랑받는 작품🥰</h2>
+				</div>
+				<div class="featured__controls">
+					<ul>
+						<li data-filter="*">전체</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+		<!-- Categories Section Begin -->
+		<section class="categories">
+			<div class="container">
+				<div class="row">
+					<div class="categories__slider owl-carousel">
+						<c:forEach items="${BestSeller }" var="product">
+							<div class="col-lg-3">
+								<a
+									href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}">
+									<div class="categories__item set-bg"
+										data-setbg="${product.productImgurl }" style="width: 200px;">
+									</div>
+								</a>
+							</div>
+						</c:forEach>
+					</div>
+				</div>
+			</div>
+		</section>
+		<!-- Categories Section End -->
+	</div>
 </section>
 <!-- Featured Section End -->
-<br><br><br>
+<br>
+<br>
+<br>
 <!-- Banner Begin -->
 <div class="banner">
-   <div class="container">
-      <div class="row">
-         <div class="col-lg-6 col-md-6 col-sm-6">
-            <div class="banner__pic">
-               <img src="img/banner/banner01.jpg" style="max-height: 100%" alt="">
-            </div>
-         </div>
-         <div class="col-lg-6 col-md-6 col-sm-6">
-            <div class="banner__pic">
-               <img src="img/banner/banner02.jpg" alt="">
-            </div>
-         </div>
-      </div>
-   </div>
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-6 col-md-6 col-sm-6">
+				<div class="banner__pic">
+					<img src="img/banner/banner01.jpg" style="max-height: 100%" alt="">
+				</div>
+			</div>
+			<div class="col-lg-6 col-md-6 col-sm-6">
+				<div class="banner__pic">
+					<img src="img/banner/banner02.jpg" alt="">
+				</div>
+			</div>
+		</div>
+	</div>
 </div>
 <!-- Banner End -->
-<br><br><br><br>
+<br>
+<br>
+<br>
+<br>
 <!-- Latest Product Section Begin -->
 <section class="latest-product spad">
-   <div class="container">
-      <div class="row">
-         <div class="col-lg-4 col-md-6">
-            <div class="latest-product__text">
-               <h4>따끈따끈 신작✨</h4>
-               <div class="latest-product__slider owl-carousel">
-	               <div class="latest-prdouct__slider__item">
-	                  <c:forEach items="${Latest}" var="product" begin="0" end="2">
-					    <div class="col-lg-12">
-					            <a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}" class="latest-product__item">
-					                <div class="latest-product__item__pic">
-					                    <img src="${product.productImgurl}" alt="">
-					                </div>
-					                <div class="latest-product__item__text">
-					                    <h6>${product.name}</h6>
-					                    <span>${product.price}</span>
-					                </div>
-					            </a>
-					        </div>
-					</c:forEach>
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-4 col-md-6">
+				<div class="latest-product__text">
+					<h4>따끈따끈 신작✨</h4>
+					<div class="latest-product__slider owl-carousel">
+						<div class="latest-prdouct__slider__item">
+							<c:forEach items="${Latest}" var="product" begin="0" end="2">
+								<div class="col-lg-12">
+									<a
+										href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}"
+										class="latest-product__item">
+										<div class="latest-product__item__pic">
+											<img src="${product.productImgurl}" alt="">
+										</div>
+										<div class="latest-product__item__text">
+											<h6>${product.name}</h6>
+											<span>${product.price}</span>
+										</div>
+									</a>
+								</div>
+							</c:forEach>
+						</div>
+						<div class="latest-prdouct__slider__item">
+							<c:forEach items="${Latest}" var="product" begin="3" end="5">
+								<div class="col-lg-12">
+									<a
+										href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}"
+										class="latest-product__item">
+										<div class="latest-product__item__pic">
+											<img src="${product.productImgurl}" alt="">
+										</div>
+										<div class="latest-product__item__text">
+											<h6>${product.name}</h6>
+											<span>${product.price}</span>
+										</div>
+									</a>
+								</div>
+							</c:forEach>
+						</div>
 					</div>
-					<div class="latest-prdouct__slider__item">
-					<c:forEach items="${Latest}" var="product" begin="3" end="5">
-					    <div class="col-lg-12">
-					            <a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}" class="latest-product__item">
-					                <div class="latest-product__item__pic">
-					                    <img src="${product.productImgurl}" alt="">
-					                </div>
-					                <div class="latest-product__item__text">
-					                    <h6>${product.name}</h6>
-					                    <span>${product.price}</span>
-					                </div>
-					            </a>
-					        </div>
-					</c:forEach>
+				</div>
+			</div>
+			<div class="col-lg-4 col-md-6">
+				<div class="latest-product__text">
+					<h4>포인트 팡팡🎉</h4>
+					<div class="latest-product__slider owl-carousel">
+						<div class="latest-prdouct__slider__item">
+							<c:forEach items="${BigPoint}" var="product" begin="0" end="2">
+								<div class="col-lg-12">
+									<a
+										href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}"
+										class="latest-product__item">
+										<div class="latest-product__item__pic">
+											<img src="${product.productImgurl}" alt="">
+										</div>
+										<div class="latest-product__item__text">
+											<h6>${product.name}</h6>
+											<span>${product.price}</span>
+										</div>
+									</a>
+								</div>
+							</c:forEach>
+						</div>
+						<div class="latest-prdouct__slider__item">
+							<c:forEach items="${BigPoint}" var="product" begin="3" end="5">
+								<div class="col-lg-12">
+									<a
+										href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}"
+										class="latest-product__item">
+										<div class="latest-product__item__pic">
+											<img src="${product.productImgurl}" alt="">
+										</div>
+										<div class="latest-product__item__text">
+											<h6>${product.name}</h6>
+											<span>${product.price}</span>
+										</div>
+									</a>
+								</div>
+							</c:forEach>
+						</div>
 					</div>
 				</div>
-            </div>
-         </div>
-         <div class="col-lg-4 col-md-6">
-            <div class="latest-product__text">
-               <h4>포인트 팡팡🎉</h4>
-               <div class="latest-product__slider owl-carousel">
-                  <div class="latest-prdouct__slider__item">
-                  <c:forEach items="${BigPoint}" var="product" begin="0" end="2">
-				    <div class="col-lg-12">
-				            <a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}" class="latest-product__item">
-				                <div class="latest-product__item__pic">
-				                    <img src="${product.productImgurl}" alt="">
-				                </div>
-				                <div class="latest-product__item__text">
-				                    <h6>${product.name}</h6>
-				                    <span>${product.price}</span>
-				                </div>
-				            </a>
-				        </div>
-				</c:forEach>
+			</div>
+			<div class="col-lg-4 col-md-6">
+				<div class="latest-product__text">
+					<h4>사장님이 미쳤어요😆</h4>
+					<div class="latest-product__slider owl-carousel">
+						<div class="latest-prdouct__slider__item">
+							<c:forEach items="${BigDiscount}" var="product" begin="0" end="2">
+								<div class="col-lg-12">
+									<a
+										href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}"
+										class="latest-product__item">
+										<div class="latest-product__item__pic">
+											<img src="${product.productImgurl}" alt="">
+										</div>
+										<div class="latest-product__item__text">
+											<h6>${product.name}</h6>
+											<span>${product.price}</span>
+										</div>
+									</a>
+								</div>
+							</c:forEach>
+						</div>
+						<div class="latest-prdouct__slider__item">
+							<c:forEach items="${BigDiscount}" var="product" begin="3" end="5">
+								<div class="col-lg-12">
+									<a
+										href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}"
+										class="latest-product__item">
+										<div class="latest-product__item__pic">
+											<img src="${product.productImgurl}" alt="">
+										</div>
+										<div class="latest-product__item__text">
+											<h6>${product.name}</h6>
+											<span>${product.price}</span>
+										</div>
+									</a>
+								</div>
+							</c:forEach>
+						</div>
+					</div>
 				</div>
-				<div class="latest-prdouct__slider__item">
-				<c:forEach items="${BigPoint}" var="product" begin="3" end="5">
-				    <div class="col-lg-12">
-				            <a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}" class="latest-product__item">
-				                <div class="latest-product__item__pic">
-				                    <img src="${product.productImgurl}" alt="">
-				                </div>
-				                <div class="latest-product__item__text">
-				                    <h6>${product.name}</h6>
-				                    <span>${product.price}</span>
-				                </div>
-				            </a>
-				        </div>
-				</c:forEach>
-				</div>
-				</div>
-            </div>
-         </div>
-         <div class="col-lg-4 col-md-6">
-            <div class="latest-product__text">
-               <h4>사장님이 미쳤어요😆</h4>
-               <div class="latest-product__slider owl-carousel">
-                  <div class="latest-prdouct__slider__item">
-                  <c:forEach items="${BigDiscount}" var="product" begin="0" end="2">
-				    <div class="col-lg-12">
-				            <a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}" class="latest-product__item">
-				                <div class="latest-product__item__pic">
-				                    <img src="${product.productImgurl}" alt="" >
-				                </div>
-				                <div class="latest-product__item__text">
-				                    <h6>${product.name}</h6>
-				                    <span>${product.price}</span>
-				                </div>
-				            </a>
-				        </div>
-				</c:forEach>
-				</div>
-				<div class="latest-prdouct__slider__item">
-				<c:forEach items="${BigDiscount}" var="product" begin="3" end="5">
-				    <div class="col-lg-12">
-				            <a href="/lotbook/product-detail.bit?view=shop-details&sequence=${product.sequence}" class="latest-product__item">
-				                <div class="latest-product__item__pic">
-				                    <img src="${product.productImgurl}" alt="" >
-				                </div>
-				                <div class="latest-product__item__text" >
-				                    <h6>${product.name}</h6>
-				                    <span>${product.price}</span>
-				                </div>
-				            </a>
-				        </div>
-				</c:forEach>
-				</div>
-				</div>
-            </div>
-         </div>
-      </div>
-   </div>
+			</div>
+		</div>
+	</div>
 </section>
 <!-- Latest Product Section End -->
 

--- a/webapp/member-info-login.jsp
+++ b/webapp/member-info-login.jsp
@@ -120,13 +120,15 @@
 			<div class="col-lg-9">
 				<div class="hero__search">
 					<div class="hero__search__form">
-						<form action="#">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
 							<div class="hero__search__categories">통합 검색</div>
-							<input type="text" placeholder="검색어를 입력해주세요">
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
 							<button type="submit" class="site-btn">검색</button>
 						</form>
 					</div>
 				</div>
+
 			</div>
 		</div>
 	</div>

--- a/webapp/member-info.jsp
+++ b/webapp/member-info.jsp
@@ -142,13 +142,15 @@
 			<div class="col-lg-9">
 				<div class="hero__search">
 					<div class="hero__search__form">
-						<form action="#">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
 							<div class="hero__search__categories">통합 검색</div>
-							<input type="text" placeholder="검색어를 입력해주세요">
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
 							<button type="submit" class="site-btn">검색</button>
 						</form>
 					</div>
 				</div>
+
 			</div>
 		</div>
 	</div>

--- a/webapp/mypage.jsp
+++ b/webapp/mypage.jsp
@@ -140,13 +140,15 @@
 			<div class="col-lg-9">
 				<div class="hero__search">
 					<div class="hero__search__form">
-						<form action="#">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
 							<div class="hero__search__categories">통합 검색</div>
-							<input type="text" placeholder="검색어를 입력해주세요">
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
 							<button type="submit" class="site-btn">검색</button>
 						</form>
 					</div>
 				</div>
+
 			</div>
 		</div>
 	</div>

--- a/webapp/search.jsp
+++ b/webapp/search.jsp
@@ -118,13 +118,15 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 			<div class="col-lg-9">
 				<div class="hero__search">
 					<div class="hero__search__form">
-						<form action="#">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
 							<div class="hero__search__categories">통합 검색</div>
-							<input type="text" placeholder="검색어를 입력해주세요">
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
 							<button type="submit" class="site-btn">검색</button>
 						</form>
 					</div>
 				</div>
+
 			</div>
 		</div>
 	</div>

--- a/webapp/search.jsp
+++ b/webapp/search.jsp
@@ -142,6 +142,7 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 					<h2>검색 결과</h2>
 					<div class="breadcrumb__option">
 						<a href="./index.jsp">Home</a> <span>Shopping Cart</span>
+
 					</div>
 				</div>
 			</div>
@@ -153,6 +154,20 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 <!-- Shoping Cart Section Begin -->
 
 <section class="product spad">
+
+	<div class="container mb-4">
+		<div class="row">
+			<div class="col-lg-3 col-md-5">
+				<span>${searchResult.searchKeyword}</span>  
+				<span>검색결과</span> 
+				<span>${searchResult.count}</span>
+				<span>건</span>
+			</div>
+			
+			<div class="col-lg-3 col-md-5"  style="margin-left: auto; text-align: right;">${searchResult.orderBy} </div>
+		</div>
+	</div>
+
 
 	<div class="container">
 		<div class="row">
@@ -204,7 +219,8 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 				</div>
 			</div>
 
-
+			<!-- TODO:조건부로 검색결과 없다고 띄우기  -->
+			
 			<div class="col-lg-9">
 				<div class="shoping__cart__table">
 					<c:forEach var="item" items="${searchResult.searchList}">
@@ -214,31 +230,31 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 							var="formattedDate" />
 
 
-						<div class="d-flex col-lg-12 py-4" style="border-top: 1px solid #d5d5d5;">
+						<div class="d-flex col-lg-12 py-4"
+							style="border-top: 1px solid #d5d5d5;">
 							<div class="mr-4 shoping__cart__item">
-								<img src="${item.productImgurl }" class="img-fluid rounded-3" style="width: 150px;" alt="" />
+								<img src="${item.productImgurl }" class="img-fluid rounded-3"
+									style="width: 150px;" alt="" />
 							</div>
 
 							<div class="d-flex flex-column justify-content-center">
 								<div class="my-2">
-									<span>[도서]</span> <h5 class="font-weight-bold d-inline">${item.name}</h5>
+									<span>[도서]</span>
+									<h5 class="font-weight-bold d-inline">${item.name}</h5>
 								</div>
-								<div >
-									<span>${item.authorName}</span> <span>저</span>
-									<br class="my-2"/>
+								<div>
+									<span>${item.authorName}</span> <span>저</span> <br class="my-2" />
 									<span>${item.publisherName}</span> <span>${ formattedDate }</span>
 								</div>
 								<div class="mt-1">
-									
-									<span class="text-warning font-weight-bold">
-	                          			<c:set var="discount" value="${item.discountRate }"/>
-										<fmt:formatNumber type="number" value="${discount}" />
-										% 할인
-							  		</span>
-									<span>${item.discountedPrice}</span><span>원</span> 
-									
-									<span style="text-decoration: line-through; color: #767676;">${item.price}</span> 
-									<span>${item.pointAccumulation}p(${item.pointAccumulationRate}%)</span>
+
+									<span class="text-warning font-weight-bold"> <c:set
+											var="discount" value="${item.discountRate }" /> <fmt:formatNumber
+											type="number" value="${discount}" /> % 할인
+									</span> <span>${item.discountedPrice}</span><span>원</span> <span
+										style="text-decoration: line-through; color: #767676;">${item.price}</span>
+									<span> | ${item.pointAccumulation}p
+										(${item.pointAccumulationRate}%)</span>
 								</div>
 								<div class="mt-2">
 									<span>판매지수: ${item.popularity } |</span> <span>회원리뷰(</span> <span
@@ -247,7 +263,7 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 								</div>
 							</div>
 
-							<div class="d-flex flex-column" style="margin-left:auto;">
+							<div class="d-flex flex-column" style="margin-left: auto;">
 								<div class="quantity">
 									<div class="pro-qty">
 										<input type="text" value="1">

--- a/webapp/search.jsp
+++ b/webapp/search.jsp
@@ -141,7 +141,7 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 				<div class="breadcrumb__text">
 					<h2>검색 결과</h2>
 					<div class="breadcrumb__option">
-						<a href="./index.jsp">Home</a> <span>Shopping Cart</span>
+						<a href="./index.jsp">Home</a> <span>Search</span>
 
 					</div>
 				</div>
@@ -158,13 +158,22 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 	<div class="container mb-4">
 		<div class="row">
 			<div class="col-lg-3 col-md-5">
-				<span>${searchResult.searchKeyword}</span>  
-				<span>검색결과</span> 
-				<span>${searchResult.count}</span>
+				<span>${searchResult.searchKeyword}</span> <span>검색결과</span> <span>${searchResult.count}</span>
 				<span>건</span>
 			</div>
-			
-			<div class="col-lg-3 col-md-5"  style="margin-left: auto; text-align: right;">${searchResult.orderBy} </div>
+
+
+			<div style="margin-left: auto; text-align: right;">
+				<!-- 드롭다운 메뉴를 생성하고 선택한 옵션에 따라 요청을 보내는 함수를 호출합니다. -->
+				<label for="orderby"></label> <select id="orderby"
+					style="margin-left: auto;" onchange="changeOrderBy(this.value)">
+					<option value="popular">인기순</option>
+					<option value="high_to_low">높은 가격순</option>
+					<option value="low_to_high">낮은 가격순</option>
+					<option value="latest">최신순</option>
+					<option value="sales">판매량순</option>
+				</select>
+			</div>
 		</div>
 	</div>
 
@@ -172,7 +181,7 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 	<div class="container">
 		<div class="row">
 			<div class="col-lg-3 col-md-5">
-				<div class="sidebar">
+				<div class="sidebar" style="position: sticky; top: 32px;">
 					<div class="sidebar__item">
 						<h4>전체 카테고리</h4>
 						<ul>
@@ -180,8 +189,9 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 							<li value="1"><a href="#" class="font-weight-bold">컴퓨터 /
 									IT</a>
 							<li value="2"><a href="#" style="text-indent: 20px">컴퓨터
-									공학</a>
-							<li value="3"><a href="#" style="text-indent: 20px">데이터베이스</a>
+									공학 (10)</a>
+							<li value="3"><a href="#" style="text-indent: 20px">데이터베이스
+									(8)</a>
 							<li value="4"><a href="#" style="text-indent: 20px">네트워크</a>
 							<li value="5"><a href="#" style="text-indent: 20px">프로그래밍</a>
 							<li value="6"><a href="#" class="font-weight-bold">소설</a></li>
@@ -220,67 +230,85 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 			</div>
 
 			<!-- TODO:조건부로 검색결과 없다고 띄우기  -->
-			
-			<div class="col-lg-9">
-				<div class="shoping__cart__table">
-					<c:forEach var="item" items="${searchResult.searchList}">
-						<fmt:parseDate value="${item.createdAt}"
-							pattern="yyyy-MM-dd HH:mm:ss" var="parsedDate" />
-						<fmt:formatDate value="${parsedDate}" pattern="yyyy년 MM월"
-							var="formattedDate" />
-
-
-						<div class="d-flex col-lg-12 py-4"
-							style="border-top: 1px solid #d5d5d5;">
-							<div class="mr-4 shoping__cart__item">
-								<img src="${item.productImgurl }" class="img-fluid rounded-3"
-									style="width: 150px;" alt="" />
-							</div>
-
-							<div class="d-flex flex-column justify-content-center">
-								<div class="my-2">
-									<span>[도서]</span>
-									<h5 class="font-weight-bold d-inline">${item.name}</h5>
-								</div>
-								<div>
-									<span>${item.authorName}</span> <span>저</span> <br class="my-2" />
-									<span>${item.publisherName}</span> <span>${ formattedDate }</span>
-								</div>
-								<div class="mt-1">
-
-									<span class="text-warning font-weight-bold"> <c:set
-											var="discount" value="${item.discountRate }" /> <fmt:formatNumber
-											type="number" value="${discount}" /> % 할인
-									</span> <span>${item.discountedPrice}</span><span>원</span> <span
-										style="text-decoration: line-through; color: #767676;">${item.price}</span>
-									<span> | ${item.pointAccumulation}p
-										(${item.pointAccumulationRate}%)</span>
-								</div>
-								<div class="mt-2">
-									<span>판매지수: ${item.popularity } |</span> <span>회원리뷰(</span> <span
-										class="text-primary">${item.reviewCount }</span> <span>건)</span>
-									<span>❤❤❤❤❤</span> <span>${item.ratingAvg }</span>
-								</div>
-							</div>
-
-							<div class="d-flex flex-column" style="margin-left: auto;">
-								<div class="quantity">
-									<div class="pro-qty">
-										<input type="text" value="1">
-									</div>
-								</div>
-								<a href="#" class="primary-btn cart-btn cart-btn-right"><span
-									class="icon_loading"></span> 카트에 넣기</a> <a href="#"
-									class="primary-btn cart-btn cart-btn-right"><span
-									class="icon_loading"></span> 바로 구매</a>
-							</div>
+			<c:choose>
+				<c:when test="${searchResult.count eq 0}">
+					<div class="d-flex flex-column align-items-center justify-content-center col-lg-9" >
+						<div class="my-5">
+							<span>${searchResult.searchKeyword}</span> 
+							<span>에 대한	검색결과가 없습니다.</span>
 						</div>
-					</c:forEach>
-				</div>
-			</div>
+						<p>입력한 검색어의 철자 또는 띄어쓰기가 정확한지 다시 한번 확인해 주세요.</p>
+					</div>
+				</c:when>
+				<c:otherwise>
+
+					<div class="col-lg-9 pr-0">
+						<div class="shoping__cart__table">
+							<c:forEach var="item" items="${searchResult.searchList}">
+								<fmt:parseDate value="${item.createdAt}"
+									pattern="yyyy-MM-dd HH:mm:ss" var="parsedDate" />
+								<fmt:formatDate value="${parsedDate}" pattern="yyyy년 MM월"
+									var="formattedDate" />
+
+
+								<div class="d-flex col-lg-12 py-4 pr-0"
+									style="border-top: 1px solid #d5d5d5; transition: box-shadow 0.3s, cursor 0.3s;"
+									onmouseover="this.style.cursor='pointer'; this.style.boxShadow='0px 4px 8px rgba(0, 0, 0, 0.1)'"
+									onmouseout="this.style.cursor='default'; this.style.boxShadow='none'"
+									onclick="redirectToProductDetail(${item.sequence}); return false;">
+
+									<div class="mr-4 shoping__cart__item">
+										<img src="${item.productImgurl }" class="img-fluid rounded-3"
+											style="width: 150px;" alt="" />
+									</div>
+
+									<div class="d-flex flex-column justify-content-center">
+										<div class="my-2">
+											<span>[도서]</span>
+											<h5 class="font-weight-bold d-inline">${item.name}</h5>
+										</div>
+										<div>
+											<span>${item.authorName}</span> <span>저</span> <br
+												class="my-2" /> <span>${item.publisherName}</span> <span>${ formattedDate }</span>
+										</div>
+										<div class="mt-1">
+
+											<span class="text-warning font-weight-bold"> <c:set
+													var="discount" value="${item.discountRate }" /> <fmt:formatNumber
+													type="number" value="${discount}" /> % 할인
+											</span> <span>${item.discountedPrice}</span><span>원</span> <span
+												style="text-decoration: line-through; color: #767676;">${item.price}</span>
+											<span> | ${item.pointAccumulation}p
+												(${item.pointAccumulationRate}%)</span>
+										</div>
+										<div class="mt-2">
+											<span>판매지수: ${item.popularity } |</span> <span>회원리뷰(</span> <span
+												class="text-primary">${item.reviewCount }</span> <span>건)</span>
+											<span>❤❤❤❤❤</span> <span>${item.ratingAvg }</span>
+										</div>
+									</div>
+
+									<div class="d-flex flex-column justify-content-center"
+										style="margin-left: auto;">
+
+										<a href="#" class="primary-btn cart-btn cart-btn-right mb-2"
+											onclick='addToCart(${item.sequence}, ${logincust.sequence}); event.stopPropagation(); return false;'>카트에
+											넣기</a> <a href="#" class="primary-btn text-white btn"
+											onclick='checkOutBuyNow(${item.sequence}, ${logincust.sequence}); event.stopPropagation(); return false;'>바로
+											구매</a>
+
+									</div>
+
+								</div>
+							</c:forEach>
+						</div>
+					</div>
+				</c:otherwise>
+			</c:choose>
 
 		</div>
 
+		<!-- 페이지네이션
 		<div class="row">
 			<div class="col-lg-12">
 				<div class="shoping__cart__btns">
@@ -311,7 +339,108 @@ List<SearchProductMapper> searchedList = searchResult.getSearchList();
 				</div>
 			</div>
 		</div>
+		 -->
 	</div>
 </section>
 <!-- Product Section End -->
 <!-- Shoping Cart Section End -->
+
+
+<!-- Modal -->
+<div class="modal fade" id="addToCartModal" tabindex="-1" role="dialog"
+	aria-labelledby="addToCartModalLabel" aria-hidden="true">
+	<div class="modal-dialog modal-dialog-centered mt-sm-3 mt-md-5 mt-lg-6"
+		role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="addToCartModalLabel">장바구니 추가</h5>
+				<button type="button" class="close" data-dismiss="modal"
+					aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</div>
+			<div class="modal-body">장바구니에 상품을 담았습니다. 장바구니로 이동하시겠습니까?</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-secondary" data-dismiss="modal">취소</button>
+				<a
+					href="main.bit?view=shopping-cart&memberSeq=${logincust.sequence}"
+					class="btn btn-danger">장바구니로 가기</a>
+			</div>
+		</div>
+	</div>
+</div>
+
+
+
+<script>
+		window.onload = function () {
+		    var currentURL = new URL(window.location.href);
+		    var selectedOrderBy = currentURL.searchParams.get("orderby");
+		    console.log(selectedOrderBy)
+		    
+		    if (selectedOrderBy) {
+		        document.getElementById("orderby").value = selectedOrderBy;
+		    }
+		};
+
+        // 정렬 기준을 변경.
+        function changeOrderBy(orderBy) {
+            var currentURL = window.location.href;
+            
+            // 쿼리 스트링에서 orderby 값을 변경.
+            var newURL = currentURL.replace(/(\?|&)orderby=[^&]*/, '');
+            if (newURL.indexOf('?') === -1) {
+                newURL += '?';
+            } else {
+                newURL += '&';
+            }
+            newURL += 'orderby=' + orderBy;
+            
+            // 변경된 URL로 페이지를 이동.
+            window.location.href = newURL;
+        }
+        
+        function redirectToProductDetail(sequence) {
+            var productDetailURL = 'http://localhost:8080/lotbook/product-detail.bit?view=shop-details&sequence=' + sequence;
+            window.location.href = productDetailURL;
+        }
+        
+        
+        $(document).ready(function() {
+    		$("#addToCartButton").click(function() {
+    			$("#addToCartModal").modal("show");
+    		});
+    	});
+    	
+    	function addToCart(productSeq, memberSeq) {
+    		if (memberSeq === undefined) {
+    	        alert("로그인이 필요합니다.");
+    	        return;
+    	    }
+    		
+    		// var count = Number($('#productQuantity').val());
+    		
+    		$.ajax({
+    			url:'rest.bit?view=addToCart&productSequence=' + productSeq + '&count=' + 1 + '&memberSeq=' + memberSeq,
+    			success:function(result){
+    				console.log(result);
+    				if (result === 0) {
+    					alert("카트에 넣는 도중 오류가 발생했습니다. 다시 시도해주세요.");
+    				} else {
+    					 $('#addToCartModal').modal('show');
+    					
+    				}
+    			}
+    		});
+    	}
+    	
+    	function checkOutBuyNow(productSeq, memberSeq) {
+    	    // var count = Number($('#productQuantity').val());
+    	    if (memberSeq === undefined) {
+    	        alert("로그인이 필요합니다.");
+    	        return;
+    	    }
+    	    // Redirect to the checkout page with the specified count and product ID
+    	    window.location.href = 'main.bit?view=checkoutbuynow&count=' + 1 + '&productId=' + productSeq + '&memberSeq=' + memberSeq;
+    	}
+</script>

--- a/webapp/shop-details.jsp
+++ b/webapp/shop-details.jsp
@@ -157,9 +157,10 @@ if (productDetailWithReviews != null) {
 			<div class="col-lg-9">
 				<div class="hero__search">
 					<div class="hero__search__form">
-						<form action="#">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
 							<div class="hero__search__categories">통합 검색</div>
-							<input type="text" placeholder="검색어를 입력해주세요">
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
 							<button type="submit" class="site-btn">검색</button>
 						</form>
 					</div>

--- a/webapp/shoping-cart.jsp
+++ b/webapp/shoping-cart.jsp
@@ -137,13 +137,15 @@
 			<div class="col-lg-9">
 				<div class="hero__search">
 					<div class="hero__search__form">
-						<form action="#">
+						<form action="#"
+							onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
 							<div class="hero__search__categories">통합 검색</div>
-							<input type="text" placeholder="검색어를 입력해주세요">
+							<input type="text" id="keyword" placeholder="검색어를 입력해주세요">
 							<button type="submit" class="site-btn">검색</button>
 						</form>
 					</div>
 				</div>
+
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## MR 이유
- [ X] Feature 병합
- [ ] 버그 수정(아래에 상세 기입)
- [ ] 코드 개선
- [ ] 주기적인 master 병합
- [ ] 기타(아래에 상세 기입)

## 스크린샷 또는 세부 내용
- 세부사항을 항목으로 설명
검색 예외처리 예시
![image](https://github.com/Hyevvy/lotbook/assets/109272333/5a817a7e-e38f-4c6e-94aa-3c97eef8eb6c)
![image](https://github.com/Hyevvy/lotbook/assets/109272333/c2aa8b8b-3959-4562-9e6e-cd926fe2bc60)




![image](https://github.com/Hyevvy/lotbook/assets/109272333/037912c7-7243-46ce-9bb0-2ae7b76a50b1)

![image](https://github.com/Hyevvy/lotbook/assets/109272333/216ce843-4f48-46a2-af13-03e23cf06ec5)
스크롤 내릴떄 카테고리 따라오게 sticky로 해놨습니다.

높은 가격순 반영된 예시
![image](https://github.com/Hyevvy/lotbook/assets/109272333/89dfe4f8-9c82-4070-9a23-383f0b973975)

![image](https://github.com/Hyevvy/lotbook/assets/109272333/02c840cb-3ea3-4f7a-9473-624b1ca7a1b2)
상품디테일에서 넘어가는거랑 동일한 로직인데 count만 1개로 해뒀습니다.


TODO: 
정렬기준 변경시, 화면에 떠있는 정렬기준은 인기순으로 고정되서 아직 화면에 안띄워지고 있음.
카테고리별 검색결과 개수 매칭하고, 클릭시 카테고리까지 반영된 검색결과 보여줘야함.

상품상세페이지 댓글 UI 아직 안꾸몄음


## MR 전 확인
- [ X] 정상 작동
- [ ] Conflict 발생 - 팀원과의 상의 필요